### PR TITLE
Rename MRS station (to INO) and add year 2023

### DIFF
--- a/trunk/Forms/DownloadManagerDialog/DownloadManagerDialog.cpp
+++ b/trunk/Forms/DownloadManagerDialog/DownloadManagerDialog.cpp
@@ -149,7 +149,7 @@ void DownloadManagerDialog::selectAllStations(bool selected) {
     ABS_checkBox->setChecked( selected );
     CYL_checkBox->setChecked( selected );
     NPT_checkBox->setChecked( selected );
-    MRS_checkBox->setChecked( selected );
+    INO_checkBox->setChecked( selected );
     TNB_checkBox->setChecked( selected );
 }
 
@@ -228,7 +228,7 @@ void DownloadManagerDialog::enableAllStations(bool selected) {
     ABS_checkBox->setEnabled( selected );
     CYL_checkBox->setEnabled( selected );
     NPT_checkBox->setEnabled( selected );
-    MRS_checkBox->setEnabled( selected );
+    INO_checkBox->setEnabled( selected );
     TNB_checkBox->setEnabled( selected );
 }
 
@@ -479,7 +479,7 @@ int MainWindow::doDownloadManagerDialog( QString &s_DownloadPath, QString &s_FTP
     dialog.LYU_checkBox->setChecked( b_Station[LYU] );
     dialog.MAN_checkBox->setChecked( b_Station[MAN] );
     dialog.MNM_checkBox->setChecked( b_Station[MNM] );
-    dialog.MRS_checkBox->setChecked( b_Station[MRS] );
+    dialog.INO_checkBox->setChecked( b_Station[INO] );
     dialog.NAU_checkBox->setChecked( b_Station[NAU] );
     dialog.NEW_checkBox->setChecked( b_Station[NEW] );
     dialog.NPT_checkBox->setChecked( b_Station[NPT] );
@@ -647,7 +647,7 @@ int MainWindow::doDownloadManagerDialog( QString &s_DownloadPath, QString &s_FTP
         b_Station[LYU]  = dialog.LYU_checkBox->isChecked();
         b_Station[MAN]  = dialog.MAN_checkBox->isChecked();
         b_Station[MNM]  = dialog.MNM_checkBox->isChecked();
-        b_Station[MRS]  = dialog.MRS_checkBox->isChecked();
+        b_Station[INO]  = dialog.INO_checkBox->isChecked();
         b_Station[NAU]  = dialog.NAU_checkBox->isChecked();
         b_Station[NEW]  = dialog.NEW_checkBox->isChecked();
         b_Station[NPT]  = dialog.NPT_checkBox->isChecked();

--- a/trunk/Forms/DownloadManagerDialog/DownloadManagerDialog.cpp
+++ b/trunk/Forms/DownloadManagerDialog/DownloadManagerDialog.cpp
@@ -347,6 +347,7 @@ void DownloadManagerDialog::selectAllYears(bool selected) {
     Year2020_checkBox->setChecked( selected );
     Year2021_checkBox->setChecked( selected );
     Year2022_checkBox->setChecked( selected );
+    Year2023_checkBox->setChecked( selected );
 }
 void DownloadManagerDialog::enableAllYears(bool selected) {
     Year1992_checkBox->setEnabled( selected );
@@ -380,6 +381,7 @@ void DownloadManagerDialog::enableAllYears(bool selected) {
     Year2020_checkBox->setEnabled( selected );
     Year2021_checkBox->setEnabled( selected );
     Year2022_checkBox->setEnabled( selected );
+    Year2023_checkBox->setEnabled( selected );
 }
 void DownloadManagerDialog::SelectAllYears()
 {
@@ -565,6 +567,7 @@ int MainWindow::doDownloadManagerDialog( QString &s_DownloadPath, QString &s_FTP
     dialog.Year2020_checkBox->setChecked( b_Year[29] );
     dialog.Year2021_checkBox->setChecked( b_Year[30] );
     dialog.Year2022_checkBox->setChecked( b_Year[31] );
+    dialog.Year2023_checkBox->setChecked( b_Year[32] );
 
     // Options
     dialog.DecompressFiles_checkBox->setChecked( b_DecompressFiles );
@@ -732,6 +735,7 @@ int MainWindow::doDownloadManagerDialog( QString &s_DownloadPath, QString &s_FTP
         b_Year[29]	= dialog.Year2020_checkBox->isChecked();
         b_Year[30]	= dialog.Year2021_checkBox->isChecked();
         b_Year[31]	= dialog.Year2022_checkBox->isChecked();
+        b_Year[32]	= dialog.Year2023_checkBox->isChecked();
 
         b_DecompressFiles	= dialog.DecompressFiles_checkBox->isChecked();
         b_CheckFiles		= dialog.CheckFiles_checkBox->isChecked();

--- a/trunk/Forms/DownloadManagerDialog/downloadmanagerdialog.ui
+++ b/trunk/Forms/DownloadManagerDialog/downloadmanagerdialog.ui
@@ -283,9 +283,9 @@
              </widget>
             </item>
             <item row="5" column="0">
-             <widget class="QCheckBox" name="MRS_checkBox">
+             <widget class="QCheckBox" name="INO_checkBox">
               <property name="text">
-               <string>MRS</string>
+               <string>INO</string>
               </property>
              </widget>
             </item>

--- a/trunk/Forms/DownloadManagerDialog/downloadmanagerdialog.ui
+++ b/trunk/Forms/DownloadManagerDialog/downloadmanagerdialog.ui
@@ -1008,6 +1008,13 @@
               </property>
              </widget>
             </item>
+            <item row="3" column="3">
+             <widget class="QCheckBox" name="Year2023_checkBox">
+              <property name="text">
+               <string>2023</string>
+              </property>
+             </widget>
+            </item>
            </layout>
           </item>
           <item row="1" column="0">

--- a/trunk/Headers/Globals.h
+++ b/trunk/Headers/Globals.h
@@ -178,6 +178,6 @@
     const int   CYL = 85; // 2021-04-30
     const int   ABS = 86; // 2021-04-30
     const int   NPT = 87; // 2021-04-30
-    const int   MRS = 88; // 2021-04-30
+    const int   INO = 88; // 2021-04-30
     const int   TNB = 89; // 2021-04-30
 #endif

--- a/trunk/Sources/ApplicationTools.cpp
+++ b/trunk/Sources/ApplicationTools.cpp
@@ -741,7 +741,7 @@ int MainWindow::writeDefaultIDsBSRN( const QString &s_Filename )
     tout << "85\tCYL\tCyI PROTEAS\t2999" << endl;
     tout << "86\tABS\tAbashiri\t2999" << endl;
     tout << "87\tNPT\tNakhon Pathom\t2999" << endl;
-    tout << "88\tMRS\tMagurele\t2999" << endl;
+    tout << "88\tINO\tMagurele\t2999" << endl;
     tout << "89\tTNB\tTerra Nova Bay\t2999" << endl;
 
     tout << "[Staff]" << endl;


### PR DESCRIPTION
Hi BSRN maintainers & users,

I propose this pull request after my visit to Amelie Driemel at AWI, and will help her in the future to maintain the software. 
The two commits propose to add a new year to the application. It also correct a station name following an ID change : MRS :arrow_right:  INO.

__Changes__ :

- Add year 2023,
- Rename MRS station to INO.

Regards,
Mathieu